### PR TITLE
BosunUrl has the Uri type

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ First, create a `MetricsCollector` object. This is the top-level container which
 var collector = new MetricsCollector(new BosunOptions(ex => HandleException(ex))
 {
 	MetricsNamePrefix = "app_name.",
-	BosunUrl = "http://bosun.mydomain.com:8070",
+	BosunUrl = new Uri("http://bosun.mydomain.com:8070"),
 	PropertyToTagName = NameTransformers.CamelToLowerSnakeCase,
 	DefaultTags = new Dictionary<string, string> 
 		{ {"host", NameTransformers.Sanitize(Environment.MachineName.ToLower())} }


### PR DESCRIPTION
And this error exists in https://nickcraver.com/blog/2018/11/29/stack-overflow-how-we-do-monitoring/
